### PR TITLE
Proxy on package repositories

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,7 +38,7 @@ class instana_agent::install {
       ensure  => 'present',
       id      => 'B878152E2F084D46F878FA20BED2D0969BAD82DE',
       source  => 'https://packages.instana.io/Instana.gpg',
-      options => "http-proxy=\"${instana_agent_proxy_type}://${instana_agent_proxy_username}:${instana_agent_proxy_password}@${instana_agent_proxy_host}:${instana_agent_proxy_port}\""
+      options => "http-proxy=\"${$instana_agent::instana_agent_proxy_type}://${$instana_agent::instana_agent_proxy_username}:${$instana_agent::instana_agent_proxy_password}@${$instana_agent::instana_agent_proxy_host}:${$instana_agent::instana_agent_proxy_port}\""
     }
 
     apt::source { 'instana-agent':
@@ -86,9 +86,9 @@ class instana_agent::install {
       gpgcheck       => true,
       repo_gpgcheck  => true,
       sslverify      => true,
-      proxy          => "${instana_agent_proxy_type}://${instana_agent_proxy_host}:${instana_agent_proxy_port}",
-      proxy_username => $instana_agent_proxy_username,
-      proxy_password => $instana_agent_proxy_password
+      proxy          => "${$instana_agent::instana_agent_proxy_type}://${$instana_agent::instana_agent_proxy_host}:${$instana_agent::instana_agent_proxy_port}",
+      proxy_username => $instana_agent::instana_agent_proxy_username,
+      proxy_password => $instana_agent::instana_agent_proxy_password
     }
     Yumrepo['Instana-Agent']
       ~> Package["instana-agent-${$instana_agent::instana_agent_flavor}"]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,9 +35,10 @@ class instana_agent::install {
     include ::apt
 
     apt::key { 'puppetlabs':
-      ensure => 'present',
-      id     => 'B878152E2F084D46F878FA20BED2D0969BAD82DE',
-      source => 'https://packages.instana.io/Instana.gpg',
+      ensure  => 'present',
+      id      => 'B878152E2F084D46F878FA20BED2D0969BAD82DE',
+      source  => 'https://packages.instana.io/Instana.gpg',
+      options => "http-proxy=\"${instana_agent_proxy_type}://${instana_agent_proxy_username}:${instana_agent_proxy_password}@${instana_agent_proxy_host}:${instana_agent_proxy_port}\""
     }
 
     apt::source { 'instana-agent':
@@ -77,14 +78,17 @@ class instana_agent::install {
 
   if ($family == 'redhat') {
     yumrepo { 'Instana-Agent':
-      ensure        => 'present',
-      assumeyes     => true,
-      baseurl       => "${$pkg_src}/generic/x86_64",
-      enabled       => true,
-      gpgkey        => 'https://packages.instana.io/Instana.gpg',
-      gpgcheck      => true,
-      repo_gpgcheck => true,
-      sslverify     => true,
+      ensure         => 'present',
+      assumeyes      => true,
+      baseurl        => "${$pkg_src}/generic/x86_64",
+      enabled        => true,
+      gpgkey         => 'https://packages.instana.io/Instana.gpg',
+      gpgcheck       => true,
+      repo_gpgcheck  => true,
+      sslverify      => true,
+      proxy          => "${instana_agent_proxy_type}://${instana_agent_proxy_host}:${instana_agent_proxy_port}",
+      proxy_username => $instana_agent_proxy_username,
+      proxy_password => $instana_agent_proxy_password
     }
     Yumrepo['Instana-Agent']
       ~> Package["instana-agent-${$instana_agent::instana_agent_flavor}"]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "instana-instana_agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Stefan Staudenmeyer <stefan.staudenmeyer@instana.com>",
   "summary": "Installs/Configures instana_agent",
   "license": "Apache-2.0",


### PR DESCRIPTION
Proxy settings are also used when retrieving system packages. Only works with RPM repositories for now.